### PR TITLE
Added Product expiry date validation and fix date format for validation

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -181,6 +181,11 @@ class ProductController extends Controller
             'is_active' => 'boolean',
             'brand_id' => 'nullable|exists:collections,id', // Assuming brands table exists
             'category_id' => 'nullable|exists:collections,id', // Assuming categories table exists
+            'expiry_date' => [
+                'nullable',
+                'date',
+//                'after_or_equal:today', // Ensures the expiry date is today or a future date
+            ],
         ]);
 
         $imageUrl = null;
@@ -230,7 +235,7 @@ class ProductController extends Controller
         $productBatch = ProductBatch::create([
             'product_id' => $product->id,
             'batch_number' => $request->batch_number ?: 'DEFAULT',
-            'expiry_date' => Carbon::parse($request->expiry_date)->format('Y-m-d'),
+            'expiry_date' => $request->expiry_date ? Carbon::parse($request->expiry_date)->format('Y-m-d') : null,
             'cost' => $request->cost,
             'price' => $request->price,
             'contact_id' => $request->contact_id,
@@ -487,13 +492,14 @@ class ProductController extends Controller
             ],
             'cost' => 'required|numeric|min:0',
             'price' => 'required|numeric|min:0',
+            'expiry_date' => 'nullable|date',
         ]);
 
         $batch->update([
             'batch_number' => $validatedData['batch_number'], // Map 'new_batch' to 'batch_number'
             'cost' => $validatedData['cost'],
             'price' => $validatedData['price'],
-            'expiry_date' => Carbon::parse($request->expiry_date)->format('Y-m-d'),
+            'expiry_date' => $request->expiry_date ? Carbon::parse($request->expiry_date)->format('Y-m-d') : null,
             'is_active' => $request->is_active ?? 0,
             'is_featured' => $request->is_featured ?? 0,
             'contact_id' => $request->contact_id,

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -183,7 +183,7 @@ class ProductController extends Controller
             'category_id' => 'nullable|exists:collections,id', // Assuming categories table exists
             'expiry_date' => [
                 'nullable',
-                'date',
+                'date_format:m/d/y',
 //                'after_or_equal:today', // Ensures the expiry date is today or a future date
             ],
         ]);

--- a/resources/js/Pages/Product/ProductForm.jsx
+++ b/resources/js/Pages/Product/ProductForm.jsx
@@ -423,7 +423,6 @@ export default function Product({ product, collection, product_code, contacts, p
                                         <DatePicker
                                             name="expiry_date"
                                             label="Expiry Date"
-                                            format="MM/DD/YY"
                                             className="w-full"
                                         />
                                     </LocalizationProvider>

--- a/resources/js/Pages/Product/ProductForm.jsx
+++ b/resources/js/Pages/Product/ProductForm.jsx
@@ -387,7 +387,7 @@ export default function Product({ product, collection, product_code, contacts, p
                                         onChange={handleChange}
                                     />
                                 </Grid>
-                                
+
                                 <Grid size={{ xs: 6, sm: 2 }} className="mb-3">
                                     <TextField
                                         label="Batch number"
@@ -423,6 +423,7 @@ export default function Product({ product, collection, product_code, contacts, p
                                         <DatePicker
                                             name="expiry_date"
                                             label="Expiry Date"
+                                            format="MM/DD/YY"
                                             className="w-full"
                                         />
                                     </LocalizationProvider>
@@ -572,13 +573,13 @@ export default function Product({ product, collection, product_code, contacts, p
                         <Grid container spacing={2}>
                             <Grid size={{ xs: 12, md: 4 }}>
                                 <div className="mb-3">
-                                    
+
                                 </div>
                             </Grid>
                             <Grid size={{ xs: 12, md: 8 }}>
                                 {/* Product Description */}
                                 <div className="mb-3">
-                                    
+
                                 </div>
                             </Grid>
 


### PR DESCRIPTION
This PR includes a date validation rule for the expiry_date field. The past date restriction (``` after_or_equal:today```) is currently commented out. Please confirm whether we should enforce this validation or leave it as is.

Fixed the date format in the frontend MUI DatePicker.

Changed the format to MM/DD/YY to prevent Laravel validation issues (Laravel expects MM/DD/YY, but the previous format was DD/MM/YY, causing validation errors).

Allowed expiry_date to be nullable.
